### PR TITLE
Auth tweaks

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,6 +1,14 @@
-import { Controller, Get, Post, Request, UseGuards } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Post,
+  Request,
+  Response,
+  UseGuards,
+} from '@nestjs/common';
 
 // Passport Auth Guards
+import { AuthenticatedGuard } from '../common/guards/authenticated.guard';
 import LocalAuthGuard from './local-auth.guard';
 
 // Swagger
@@ -10,6 +18,8 @@ import {
   ApiTags,
 } from '@nestjs/swagger';
 
+// Types
+import { User } from '../users/schemas/user.schema';
 @ApiTags('auth')
 @Controller('auth')
 export class AuthController {
@@ -22,8 +32,18 @@ export class AuthController {
     description: 'Internal server error',
   })
   @Post('/login')
-  async login() {
-    return { message: 'Login successful' };
+  async login(@Response() res) {
+    res.redirect('/auth/account');
+  }
+
+  @ApiOkResponse({
+    description: "Get the currently logged in user's account.",
+    type: [User],
+  })
+  @UseGuards(AuthenticatedGuard)
+  @Get('/account')
+  getAccount(@Request() req, @Response() res) {
+    res.redirect('/users/' + req.user);
   }
 
   @ApiOkResponse({

--- a/src/main.ts
+++ b/src/main.ts
@@ -40,7 +40,9 @@ async function bootstrap() {
   }
 
   app.use(helmet());
-  app.enableCors({ credentials: true });
+
+  // let origin = configService.get<string>('NODE_ENV') === 'development' ? 'http://localhost:8000' : TODO: Production domain
+  app.enableCors({ credentials: true, origin: 'http://localhost:8000' });
   app.use(session(sess));
   app.use(passport.initialize());
   app.use(passport.session());


### PR DESCRIPTION
This PR implements the following:
- sets CORS domain to enable credentials (cookies) to be sent in req/res cycle
- GET /auth/account route for accessing user that was previously serialized to the session on login